### PR TITLE
Update nrf24l01.c

### DIFF
--- a/src/nrf24l01.c
+++ b/src/nrf24l01.c
@@ -381,7 +381,7 @@ NRF_RESULT nrf_set_crc_width(nrf24l01* dev, NRF_CRC_WIDTH width) {
     if (width == NRF_CRC_WIDTH_2B) {
         reg |= 1 << 2;
     } else {
-        reg &= ~(1 << 3);
+        reg &= ~(1 << 2);
     }
 
     if (nrf_write_register(dev, NRF_CONFIG, &reg) != NRF_OK) {
@@ -417,8 +417,10 @@ NRF_RESULT nrf_rx_tx_control(nrf24l01* dev, NRF_TXRX_STATE rx) {
 
     if (rx) {
         reg |= 1;
+	dev->state=NRF_STATE_RX;    
     } else {
         reg &= ~(1);
+	dev->state=NRF_STATE_TX;
     }
 
     if (nrf_write_register(dev, NRF_CONFIG, &reg) != NRF_OK) {


### PR DESCRIPTION
[BUGFIX]
nrf24l01.c line 384



```
NRF_RESULT nrf_set_crc_width(nrf24l01* dev, NRF_CRC_WIDTH width) {
    uint8_t reg = 0;
    if (nrf_read_register(dev, NRF_CONFIG, &reg) != NRF_OK) {
        return NRF_ERROR;
    }

    if (width == NRF_CRC_WIDTH_2B) {
        reg |= 1 << 2;
    } else {
        reg &= ~(1 << 2);    <- **how should be (was 1<<3, probably an unupdated copypaste from previous function.)**
    }
```

